### PR TITLE
fix read_cb bug, the modified version should be correct using the latest...

### DIFF
--- a/librsync/__init__.py
+++ b/librsync/__init__.py
@@ -219,9 +219,12 @@ def patch(f, d, o=None):
     @patch_callback
     def read_cb(opaque, pos, length, buff):
         f.seek(pos)
-        block = f.read(length)
-        buff.next_in = ctypes.c_char_p(block)
-        buff.avail_in = ctypes.c_size_t(len(block))
+        size_p = ctypes.cast(length, ctypes.POINTER(ctypes.c_size_t)).contents
+        size = size_p.value
+        block = f.read(size)
+        size_p.value = len(block)
+        buff_p = ctypes.cast(buff, ctypes.POINTER(ctypes.c_char_p)).contents
+        buff_p.value = block
         return RS_DONE
 
     job = _librsync.rs_patch_begin(read_cb, None)


### PR DESCRIPTION
import librsync
import os
from cStringIO import StringIO

src = 'FF'
print src
dst = 'FF123FF'
print dst
src_sig = librsync.signature(StringIO(src))
delta = librsync.delta(StringIO(dst), src_sig).read()
print delta
out = librsync.patch(StringIO(src), StringIO(delta))
print out.read()

The output from original code is:
FF
FF123FF
rs6AFF123E
FF123

Patched output is FF123 but should be FF123FF.

This pull request fixed this issue.
