### PR TITLE
Added support for librsync 1.0.0 and later, which includes a "magic"

### DIFF
--- a/librsync/__init__.py
+++ b/librsync/__init__.py
@@ -38,6 +38,9 @@ RS_JOB_BLOCKSIZE = 65536
 RS_DEFAULT_STRONG_LEN = 8
 RS_DEFAULT_BLOCK_LEN = 2048
 
+RS_DELTA_MAGIC          = 0x72730236      # r s \2 6
+RS_MD4_SIG_MAGIC        = 0x72730136      # r s \1 6
+RS_BLAKE2_SIG_MAGIC     = 0x72730137      # r s \1 7
 
 #############################
 #  DEFINES FROM librsync.h  #
@@ -60,7 +63,7 @@ _librsync.rs_strerror.argtypes = (ctypes.c_int, )
 
 # rs_job_t *rs_sig_begin(size_t new_block_len, size_t strong_sum_len);
 _librsync.rs_sig_begin.restype = ctypes.c_void_p
-_librsync.rs_sig_begin.argtypes = (ctypes.c_size_t, ctypes.c_size_t, )
+_librsync.rs_sig_begin.argtypes = (ctypes.c_size_t, ctypes.c_size_t, ctypes.c_int, )
 
 # rs_job_t *rs_loadsig_begin(rs_signature_t **);
 _librsync.rs_loadsig_begin.restype = ctypes.c_void_p
@@ -151,14 +154,12 @@ def _execute(job, f, o=None):
         o.seek(0)
     return o
 
-
 def debug(level=syslog.LOG_DEBUG):
     assert level in TRACE_LEVELS, "Invalid log level %i" % level
     _librsync.rs_trace_set_level(level)
 
-
 @seekable
-def signature(f, s=None, block_size=RS_DEFAULT_BLOCK_LEN):
+def signature(f, s=None, block_size=RS_DEFAULT_BLOCK_LEN, magic=RS_MD4_SIG_MAGIC):
     """
     Generate a signature for the file `f`. The signature will be written to `s`.
     If `s` is omitted, a temporary file will be used. This function returns the
@@ -167,13 +168,12 @@ def signature(f, s=None, block_size=RS_DEFAULT_BLOCK_LEN):
     """
     if s is None:
         s = tempfile.SpooledTemporaryFile(max_size=MAX_SPOOL, mode='wb+')
-    job = _librsync.rs_sig_begin(block_size, RS_DEFAULT_STRONG_LEN)
+    job = _librsync.rs_sig_begin(block_size, RS_DEFAULT_STRONG_LEN, magic)
     try:
         _execute(job, f, s)
     finally:
         _librsync.rs_job_free(job)
     return s
-
 
 @seekable
 def delta(f, s, d=None):


### PR DESCRIPTION
number on the rs_sig_begin() function, to specify whether to use the MD4
or Blake2 hashes.  Mostly compatible with older versions, as extra
arguments are ignored in most calling conventions.